### PR TITLE
added support for newlines to the AsciiConverter

### DIFF
--- a/lib/meteor-helper-view.coffee
+++ b/lib/meteor-helper-view.coffee
@@ -106,7 +106,7 @@ class MeteorHelperView extends View
       @mongoURL = atom.config.get 'meteor-helper.mongoURL'
       consoleColor = atom.config.get 'meteor-helper.consoleColor'
       # Create an ASCII to HTML converter
-      @converter = new AsciiConverter fg: consoleColor
+      @converter = new AsciiConverter fg: consoleColor, newline: true
       # Check if the command is installed on the system
       fs.exists meteorPath, (isCliDefined) =>
         # Set an error message if Meteor CLI cannot be found


### PR DESCRIPTION
Reading stack traces & such is difficult without newlines. Fortunately, `ansi-to-html` supports turning newlines into `<br/>`s. Please let me know what you think.
