### PR TITLE
Fix commands handling

### DIFF
--- a/keymaps/meteor-helper.cson
+++ b/keymaps/meteor-helper.cson
@@ -1,3 +1,7 @@
-'.workspace':
+'.platform-win32 atom-workspace, .platform-linux atom-workspace':
   'ctrl-alt-m': 'meteor-helper:toggle'
   'ctrl-alt-r': 'meteor-helper:reset'
+
+'.platform-darwin atom-workspace':
+  'cmd-alt-m': 'meteor-helper:toggle'
+  'cmd-alt-r': 'meteor-helper:reset'

--- a/lib/meteor-helper-view.coffee
+++ b/lib/meteor-helper-view.coffee
@@ -37,8 +37,9 @@ class MeteorHelperView extends View
     # Current pane status
     @paneIconStatus = null
     # Register toggle and reset
-    atom.workspaceView.command 'meteor-helper:reset', => @reset()
-    atom.workspaceView.command 'meteor-helper:toggle', => @toggle()
+    atom.commands.add 'atom-workspace',
+      'meteor-helper:reset': => @reset()
+      'meteor-helper:toggle': => @toggle()
     # Ensure destruction of Meteor's process
     $(window).on 'beforeunload', => @_killMeteor()
 

--- a/package.json
+++ b/package.json
@@ -3,10 +3,12 @@
   "main": "./lib/meteor-helper",
   "version": "0.18.1",
   "description": "Launch Meteor from Atom.io",
-  "activationEvents": [
-    "meteor-helper:toggle",
-    "meteor-helper:reset"
-  ],
+  "activationCommands": {
+    "atom-workspace": [
+      "meteor-helper:toggle",
+      "meteor-helper:reset"
+    ]
+  },
   "repository": "https://github.com/PEM--/meteor-helper",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
There have been changes in several areas regarding commands' declaration, registration, etc.

1. package.json now has new declaration syntax: `activationCommands` instead of `activationEvents`
2. as the workspaceView is deprecated, the proper way to register commands is `atom.commands,add`

Also to note is overall migration from class-based selectors like `.workspace` to custom elements, such as `atom-workspace` outlined [here](https://atom.io/docs/v0.166.0/upgrading/upgrading-your-ui-theme)

PS: I've accidentally added platform specific keymap commit, which, honestly, should have been done as a separate PR. If it's undesirable in this PR, I'll submit them separately.