### PR TITLE
Support for running Meteor in a configured directory

### DIFF
--- a/lib/meteor-helper-view.coffee
+++ b/lib/meteor-helper-view.coffee
@@ -126,6 +126,7 @@ class MeteorHelperView extends View
   # Returns: `undefined`
   _getSettings: ->
     # Get the configured Meteor's path, port and production flag
+    @meteorAppPath = atom.config.get 'meteor-helper.meteorAppPath'
     @meteorPath = atom.config.get 'meteor-helper.meteorPath'
     @meteorPort = atom.config.get 'meteor-helper.meteorPort'
     @isMeteorProd = atom.config.get 'meteor-helper.production'
@@ -138,7 +139,7 @@ class MeteorHelperView extends View
       throw new Error "<h3>Meteor command not found: #{@meteorPath}</h3>
         <p>You can override these setting in this package preference.</p>"
     # Check if the current project owns a Meteor project
-    meteor_project_path = path.join atom.project.getPath(), '.meteor'
+    meteor_project_path = path.join atom.project.getPath(), @meteorAppPath, '.meteor'
     isPrjCreated = fs.existsSync meteor_project_path
     # Set an error message if no Meteor project is found
     unless isPrjCreated
@@ -244,7 +245,7 @@ class MeteorHelperView extends View
         command: @meteorPath
         args: args
         options:
-          cwd: atom.project.getPath()
+          cwd: path.join atom.project.getPath(), @meteorAppPath
           env: process.env
         stdout: @paneAddInfo
         stderr: @paneAddErr

--- a/lib/meteor-helper.coffee
+++ b/lib/meteor-helper.coffee
@@ -3,6 +3,10 @@ MeteorHelperView = require './meteor-helper-view'
 module.exports =
   # Define configuration capabilities
   config:
+    meteorAppPath:
+      type: 'string'
+      description: 'The relative path to the Meteor application directory, e.g. "app"'
+      default: '.'
     meteorPath:
       type: 'string'
       description: 'Customize Meteor\'s launching command'

--- a/lib/meteor-helper.coffee
+++ b/lib/meteor-helper.coffee
@@ -7,10 +7,12 @@ module.exports =
       type: 'string'
       description: 'The relative path to the Meteor application directory, e.g. "app"'
       default: '.'
+      order: 1
     meteorPath:
       type: 'string'
       description: 'Customize Meteor\'s launching command'
       default: '/usr/local/bin/meteor'
+      order: 2
     meteorPort:
       type: 'integer'
       default: 3000
@@ -24,15 +26,20 @@ module.exports =
       type: 'boolean'
       default: false
       description: 'Add some intersting DDP logs when debugging'
+      order: 3
     mongoURL:
       type: 'string'
       default: ''
       description: 'Default Mongo installation is generally accessible at: \
         mongodb://localhost:27017'
+      order: 4
     mongoOplogURL:
       type: 'string'
       default: ''
       description: 'Default Mongo Oplog installation must match MONGO_URL'
+      order: 5
+      order: 6
+      order: 7
 
   meteorHelperView: null
 

--- a/lib/meteor-helper.coffee
+++ b/lib/meteor-helper.coffee
@@ -18,27 +18,32 @@ module.exports =
       default: 3000
       description: 'Meteor\'s default port is 3000 and Mongo\'s default port \
         is the same incremented by 1'
-    production:
-      type: 'boolean'
-      default: false
-      description: 'Used for checking production compilations'
-    debug:
-      type: 'boolean'
-      default: false
-      description: 'Add some intersting DDP logs when debugging'
       order: 3
     mongoURL:
+      title: 'Mongo URL'
       type: 'string'
       default: ''
       description: 'Default Mongo installation is generally accessible at: \
         mongodb://localhost:27017'
       order: 4
     mongoOplogURL:
+      title: 'Mongo Oplog URL'
       type: 'string'
       default: ''
       description: 'Default Mongo Oplog installation must match MONGO_URL'
       order: 5
+    debug:
+      title: 'Run in Debug Mode'
+      type: 'boolean'
+      default: false
+      description: 'Run Meteor in debug mode for connecting from debugging \
+        clients, such as node-inspector (port 5858)'
       order: 6
+    production:
+      title: 'Simulate Production'
+      type: 'boolean'
+      default: false
+      description: 'Simulate running in production by minifying the JS/CSS assets'
       order: 7
 
   meteorHelperView: null


### PR DESCRIPTION
### Summary

When using something like [Iron Meteor](https://github.com/iron-meteor/iron-cli) or when a developer has their Meteor app in a subdirectory under the project path, it was not possible to run Meteor. I added a configuration setting to allow starting Meteor in a directory other than the current working directory.

The Atom configuration supports using ordering and titles so I ordered the configuration and added titles to fix things like **Mongo Oplog U R L**.

### Change Description

- Added the `meteorAppPath` configuration setting (fb3e3ec).
- Ordered the configuration items (e6c3318).
- Some of the configuration items benefited from a better description and title (f7c8667).