### PR TITLE
support for running meteor in a mup.json configured directory

### DIFF
--- a/lib/meteor-helper.coffee
+++ b/lib/meteor-helper.coffee
@@ -7,28 +7,34 @@ module.exports = MeteorHelper =
       type: 'string'
       description: 'Customize Meteor\'s launching command'
       default: '/usr/local/bin/meteor'
+      order: 1
     meteorPort:
       type: 'integer'
       default: 3000
       description: 'Meteor\'s default port is 3000 and Mongo\'s default port \
         is the same incremented by 1'
-    production:
-      type: 'boolean'
-      default: false
-      description: 'Used for checking production compilations'
-    debug:
-      type: 'boolean'
-      default: false
-      description: 'Add some intersting DDP logs when debugging'
+      order: 2
     mongoURL:
       type: 'string'
       default: ''
       description: 'Default Mongo installation is generally accessible at: \
         mongodb://localhost:27017'
+      order: 3
     mongoOplogURL:
       type: 'string'
       default: ''
       description: 'Default Mongo Oplog installation must match MONGO_URL'
+      order: 4
+    debug:
+      type: 'boolean'
+      default: false
+      description: 'Add some intersting DDP logs when debugging'
+      order: 5
+    production:
+      type: 'boolean'
+      default: false
+      description: 'Used for checking production compilations'
+      order: 6
 
   meteorHelperView: null
 


### PR DESCRIPTION
implemented support for using the „app“ config item in an existing
mup.json file to start Meteor in a different directory other than the
current working directory 

as discussed in #29 